### PR TITLE
refactor: replace inline favicon SVGs with external assets

### DIFF
--- a/server/static/client.js
+++ b/server/static/client.js
@@ -58,31 +58,25 @@ class NeovimClient {
         let link = document.querySelector("link[rel*='icon']");
         if (!link) {
             link = document.createElement("link");
-            link.type = "image/x-icon";
+            link.type = "image/svg+xml";
             link.rel = "shortcut icon";
             document.head.appendChild(link);
         }
 
-        let svgContent;
         switch (status) {
-            case "connected":
-                svgContent =
-                    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">✅</text></svg>';
+            case "error": {
+                link.href = "neovim-inactive.svg";
                 break;
-            case "connecting":
-                svgContent =
-                    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🔄</text></svg>';
+            }
+            case "connecting": {
+                link.href = "neovim-inactive.svg";
                 break;
-            case "error":
-                svgContent =
-                    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">❌</text></svg>';
+            }
+            default: {
+                link.href = "neovim.svg";
                 break;
-            default:
-                svgContent =
-                    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">📝</text></svg>';
+            }
         }
-
-        link.href = "data:image/svg+xml," + encodeURIComponent(svgContent);
     }
 
     handleMessage(msg) {

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -4,6 +4,7 @@
 <head>
     <title>Neovim Server</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="icon" type="image/svg+xml" href="neovim.svg">
 </head>
 
 <body>

--- a/server/static/neovim-inactive.svg
+++ b/server/static/neovim-inactive.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="602px" height="734px" viewBox="0 0 602 734" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <title>neovim-mark-greyscale@2x</title>
+    <description>Created with Sketch (http://www.bohemiancoding.com/sketch)</description>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#888888" stop-opacity="0.800235524" offset="0%"></stop>
+            <stop stop-color="#444444" stop-opacity="0.83700023" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-2">
+            <stop stop-color="#666666" offset="0%"></stop>
+            <stop stop-color="#333333" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-3">
+            <stop stop-color="#777777" stop-opacity="0.8" offset="0%"></stop>
+            <stop stop-color="#444444" stop-opacity="0.84" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="mark-copy" sketch:type="MSLayerGroup" transform="translate(2.000000, 3.000000)">
+            <path d="M0,155.5704 L155,-1 L154.999997,727 L0,572.237919 L0,155.5704 Z" id="Left---green" fill="url(#linearGradient-1)" sketch:type="MSShapeGroup"></path>
+            <path d="M443.060403,156.982405 L600,-1 L596.818792,727 L442,572.219941 L443.060403,156.982405 Z" id="Right---blue" fill="url(#linearGradient-2)" sketch:type="MSShapeGroup" transform="translate(521.000000, 363.500000) scale(-1, 1) translate(-521.000000, -363.500000) "></path>
+            <path d="M154.986294,0 L558,615.189696 L445.224605,728 L42,114.172017 L154.986294,0 Z" id="Cross---blue" fill="url(#linearGradient-3)" sketch:type="MSShapeGroup"></path>
+            <path d="M155,283.83232 L154.786754,308 L31,124.710606 L42.4619486,113 L155,283.83232 Z" id="Shadow" fill-opacity="0.13" fill="#000000" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/server/static/neovim.svg
+++ b/server/static/neovim.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="602px" height="734px" viewBox="0 0 602 734" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <title>neovim-mark@2x</title>
+    <description>Created with Sketch (http://www.bohemiancoding.com/sketch)</description>
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#16B0ED" stop-opacity="0.800235524" offset="0%"></stop>
+            <stop stop-color="#0F59B2" stop-opacity="0.83700023" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-2">
+            <stop stop-color="#7DB643" offset="0%"></stop>
+            <stop stop-color="#367533" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-3">
+            <stop stop-color="#88C649" stop-opacity="0.8" offset="0%"></stop>
+            <stop stop-color="#439240" stop-opacity="0.84" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="mark-copy" sketch:type="MSLayerGroup" transform="translate(2.000000, 3.000000)">
+            <path d="M0,155.5704 L155,-1 L154.999997,727 L0,572.237919 L0,155.5704 Z" id="Left---green" fill="url(#linearGradient-1)" sketch:type="MSShapeGroup"></path>
+            <path d="M443.060403,156.982405 L600,-1 L596.818792,727 L442,572.219941 L443.060403,156.982405 Z" id="Right---blue" fill="url(#linearGradient-2)" sketch:type="MSShapeGroup" transform="translate(521.000000, 363.500000) scale(-1, 1) translate(-521.000000, -363.500000) "></path>
+            <path d="M154.986294,0 L558,615.189696 L445.224605,728 L42,114.172017 L154.986294,0 Z" id="Cross---blue" fill="url(#linearGradient-3)" sketch:type="MSShapeGroup"></path>
+            <path d="M155,283.83232 L154.786754,308 L31,124.710606 L42.4619486,113 L155,283.83232 Z" id="Shadow" fill-opacity="0.13" fill="#000000" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
- Add neovim.svg and neovim-inactive.svg icon files
- Update favicon type from image/x-icon to image/svg+xml
- Simplify status icon logic to use external SVG files
- Add default favicon link in HTML head